### PR TITLE
Switch to RCB corporate hype generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# LinkedIn Post Generator
+# RCB Corporate Post Generator
 
-A modern web application built with Next.js that generates AI-powered LinkedIn posts with different styles and flavors. The application uses GPT-4 to create engaging, viral-worthy content that mimics popular LinkedIn posting styles.
+A fun web application built with Next.js that generates sarcastic LinkedIn posts about the corporate lessons everyone claims to learn from RCB finally winning the title. The app uses GPT-4 to craft enthusiastic, tongue-in-cheek content.
 
 ## Features
 
-- **AI-Powered Post Generation**: Uses OpenAI's GPT-4 model to generate contextually relevant LinkedIn posts
-- **Multiple Post Styles**: 
-  - Straight Fire 🔥: Bold, confident, and slightly provocative
-  - Humble Brag 😌: Subtle flexing while maintaining modesty
-  - Fake Humility 🙏: Overly modest posts about achievements
+- **AI-Powered Post Generation**: Uses OpenAI's GPT-4 model to create posts riffing on RCB's big win
+- **Multiple Post Styles**:
+  - Fanatic Leadership: Channel intense captaincy energy
+  - Data-Driven Hustle: Spreadsheets meet adrenaline
+  - Never Say Die 💪: Because sixteen seasons of waiting builds character
 - **Post Management**:
   - 20 post generation limit per user
   - Copy to clipboard functionality
@@ -57,7 +57,7 @@ npm run dev
 
 ## Usage
 
-1. Click "Generate LinkedIn Post" to create your first post
+1. Click "Generate RCB Post" to create your first post
 2. After generation, you can:
    - Copy the post using the copy button
    - Provide feedback using emoji reactions

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -22,7 +22,7 @@ export async function POST(req: Request) {
       messages: [
         {
           role: "system",
-          content: `You are a LinkedIn post generator. Generate a ${flavor} style post about ${postTypeDescription}. Make it sound enthusiastic and viral-worthy, around 200 words. No emoji usage. Embody the AI techbro, short punchy sentences, bulletpoints in between, sense of self importance, and a touch of arrogance. Use a tone that is confident and slightly provocative. replace xyz with real companies and products from news`,
+          content: `You are a LinkedIn post generator. Generate a ${flavor} style post about lessons from RCB's title win for corporate life. Topic: ${postTypeDescription}. Make it enthusiastic and viral-worthy, around 200 words. No emoji usage. Keep short punchy sentences, bullet points, and a hint of sarcasm. Replace xyz with real companies and products from news`,
         }
       ],
     })

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ export default function Home() {
     <main className="flex min-h-screen flex-col items-center justify-between p-4 md:p-24">
       <div className="z-10 w-full items-center justify-between font-mono text-sm">
         <h1 className="text-4xl font-bold text-center mb-8">
-          LinkedIn Post Generator
+          RCB Corporate Post Generator
         </h1>
         
         <PostGenerator />

--- a/src/components/FlavorSelector.tsx
+++ b/src/components/FlavorSelector.tsx
@@ -3,20 +3,20 @@ import { Listbox, Transition } from '@headlessui/react'
 import { CheckIcon, ChevronUpDownIcon } from '@heroicons/react/20/solid'
 
 const FLAVORS = [
-  { 
-    id: 'humblebrag', 
-    name: 'Humble Brag', 
-    description: 'Subtle flex while appearing modest' 
+  {
+    id: 'fanatic_leadership',
+    name: 'Fanatic Leadership',
+    description: 'Channel your inner Kohli and manage by sheer passion'
   },
-  { 
-    id: 'fake_humility', 
-    name: 'Fake Humility', 
-    description: 'Overly modest about achievements' 
+  {
+    id: 'data_driven_hustle',
+    name: 'Data-Driven Hustle',
+    description: 'Every move backed by spreadsheets and adrenaline'
   },
-  { 
-    id: 'straight_fire', 
-    name: 'Straight Fire 🔥', 
-    description: 'No holds barred, pure hype' 
+  {
+    id: 'never_say_die',
+    name: 'Never Say Die',
+    description: 'Because waiting sixteen seasons builds character'
   }
 ]
 
@@ -27,14 +27,14 @@ interface FlavorSelectorProps {
 
 export default function FlavorSelector({ selectedFlavor, onFlavorSelect }: FlavorSelectorProps) {
   const flavorOptions = [
-    { id: 'straight_fire', label: 'Straight Fire 🔥' },
-    { id: 'humblebrag', label: 'Humble Brag 😌' },
-    { id: 'fake_humility', label: 'Fake Humility 🙏' }
+    { id: 'fanatic_leadership', label: 'Fanatic Leadership' },
+    { id: 'data_driven_hustle', label: 'Data-Driven Hustle' },
+    { id: 'never_say_die', label: 'Never Say Die 💪' }
   ];
 
   return (
     <div className="flex flex-col space-y-2">
-      <label className="text-sm font-medium text-gray-700">Select Post Style:</label>
+      <label className="text-sm font-medium text-gray-700">Pick Your Lesson:</label>
       <div className="flex space-x-2">
         {flavorOptions.map((option) => (
           <button

--- a/src/components/PostGenerator.tsx
+++ b/src/components/PostGenerator.tsx
@@ -15,7 +15,7 @@ interface PostType {
 }
 
 interface PostGeneratorProps {
-  flavor?: 'straight_fire' | 'fake_humility' |  'humblebrag'
+  flavor?: 'fanatic_leadership' | 'data_driven_hustle' | 'never_say_die'
 }
 
 interface GeneratedPost {
@@ -28,7 +28,7 @@ export default function PostGenerator({ flavor: initialFlavor }: PostGeneratorPr
   const [post, setPost] = useState<GeneratedPost | null>(null)
   const [loading, setLoading] = useState(false)
   const [copied, setCopied] = useState(false)
-  const [selectedFlavor, setSelectedFlavor] = useState<string>('straight_fire')
+  const [selectedFlavor, setSelectedFlavor] = useState<string>('fanatic_leadership')
   const [remainingUses, setRemainingUses] = useState(20)
   
   useEffect(() => {
@@ -42,9 +42,9 @@ export default function PostGenerator({ flavor: initialFlavor }: PostGeneratorPr
   }, [])
 
   const flavorOptions = [
-    { id: 'straight_fire', label: 'Straight Fire 🔥' },
-    { id: 'humblebrag', label: 'Humble Brag 😌' },
-    { id: 'fake_humility', label: 'Fake Humility 🙏' }
+    { id: 'fanatic_leadership', label: 'Fanatic Leadership' },
+    { id: 'data_driven_hustle', label: 'Data-Driven Hustle' },
+    { id: 'never_say_die', label: 'Never Say Die 💪' }
   ]
 
   const getRandomPostType = () => {
@@ -82,7 +82,7 @@ export default function PostGenerator({ flavor: initialFlavor }: PostGeneratorPr
     try {
       const selectedPostType = getRandomPostType();
       const body = {
-        flavor: 'straight_fire', // Always use straight_fire for first post
+        flavor: 'fanatic_leadership', // Always use this style for the first post
         postType: selectedPostType
       }
       const response = await fetch('/api/posts', {
@@ -193,7 +193,7 @@ export default function PostGenerator({ flavor: initialFlavor }: PostGeneratorPr
               <div className="flex items-center space-x-3">
                 <div className="h-12 w-12 rounded-full bg-gradient-to-r from-linkedin-blue to-linkedin-hover" />
                 <div>
-                  <h3 className="font-semibold text-linkedin-text">AI Post Generator</h3>
+                  <h3 className="font-semibold text-linkedin-text">RCB Wisdom Generator</h3>
                   <p className="text-sm text-gray-500">Generated • {new Date(post.createdAt).toLocaleDateString()}</p>
                 </div>
               </div>
@@ -265,7 +265,7 @@ export default function PostGenerator({ flavor: initialFlavor }: PostGeneratorPr
                   <span>Generating...</span>
                 </div>
               ) : (
-                'Generate LinkedIn Post'
+                'Generate RCB Post'
               )}
             </button>
           </div>

--- a/src/components/PostTypeSelector.tsx
+++ b/src/components/PostTypeSelector.tsx
@@ -3,61 +3,71 @@ import { Listbox, Transition } from '@headlessui/react'
 import { CheckIcon, ChevronUpDownIcon } from '@heroicons/react/20/solid'
 
 export const POST_TYPES = [
-  { 
-    id: 1, 
-    name: 'AI Taking All Jobs', 
-    description: 'I just fixed my kitchen leak using ChatGPT live video. The latest model is so good, there will be no software jobs from next year. Entire consulting sector is doomed...'
+  {
+    id: 1,
+    name: 'Never Give Up',
+    description:
+      'Sixteen seasons of heartbreak and finally a trophy. Persistence is apparently the ultimate KPI.'
   },
-  { 
-    id: 2, 
-    name: 'Human Superiority', 
-    description: "I just asked ChatGPT to do xyz and it couldn't. To experts, AI responses are too bad, mediocrity in a field you don't know sounds brilliant..."
+  {
+    id: 2,
+    name: 'Hire Superstar Talent',
+    description:
+      "Poach impact players mid-season like you're grabbing your rival's star engineer the day before launch."
   },
-  { 
-    id: 3, 
-    name: 'AI so good', 
-    description: 'I just saw a junior finish 10 hours of work in one hour, I just made an app in 2 minutes, AI is bad but those who know how to use it are great...'
+  {
+    id: 3,
+    name: 'Brand Building 101',
+    description:
+      "Kohli sells more jerseys than wins. Pump up social presence even if results lag behind."
   },
-  { 
-    id: 4, 
-    name: 'Comment farming Promo', 
-    description: 'Get my prompt guide on xyz topic, this literally changes the whole field, comment AI guide below to get the free guide worth thousands of dollars...'
+  {
+    id: 4,
+    name: 'Data-Driven Decisions',
+    description:
+      'Match-ups, powerplays, spreadsheets. Imagine using analytics before each Monday meeting.'
   },
-  { 
-    id: 5, 
-    name: 'Product Launch hype', 
-    description: 'Company x just launched AI product xyz. This is brilliant it can do soo soo much, its groundbreaking, this changes everything...'
+  {
+    id: 5,
+    name: 'Fan Engagement Mania',
+    description:
+      'Fans stuck around for years of memes. Keep customers cheering even when the product is buggy.'
   },
-  { 
-    id: 6, 
-    name: 'AI Masterclass that no one asked for', 
-    description: 'This person dropped the full course on how to do xyz with AI, watch the 10 hour masterclass...'
+  {
+    id: 6,
+    name: 'Leadership Overhaul',
+    description:
+      'New captain, new success. Sometimes that outsider CEO vibe is all you need.'
   },
-  { 
-    id: 7, 
-    name: 'AI Criticism and Hallucinations', 
-    description: 'AI is making xyz worse, its full of hallucinations, inaccuracies...'
+  {
+    id: 7,
+    name: 'Play Bold Culture',
+    description:
+      'The motto finally paid off. Maybe drop the corporate-safe talk and embrace risk.'
   },
-  { 
-    id: 8, 
-    name: 'try AI for everything', 
-    description: 'Try therapy with AI, interviews with AI, conflict resolution with AI, quote full made up stories of personal experiences...'
+  {
+    id: 8,
+    name: 'Celebration Overload',
+    description:
+      "They partied like there's no tomorrow. Hold more town halls for small wins too."
   },
-  { 
-    id: 9, 
-    name: 'Make with AI only after my course', 
-    description: 'Join my masterclass on how to build full end to end apps with AI, why use LinkedIn when you can make your own, make your CRM...'
+  {
+    id: 9,
+    name: 'Merch and Money',
+    description:
+      'Victory tees sold out in minutes. Can your team monetize success this fast?'
   },
-  { 
-    id: 10, 
-    name: 'Agent Workflow', 
-    description: 'Announce an agentic workflow they have created, connect random apps with each other and ask people to comment xyz to get it...'
+  {
+    id: 10,
+    name: 'From Chokers to Champions',
+    description:
+      'Rebrand the narrative after one good quarter. Works for sports, works for business.'
   }
 ]
 
 interface PostTypeSelectorProps {
-  selected: number;
-  setSelected: (value: number) => void;
+  selected: number
+  setSelected: (value: number) => void
 }
 
 export default function PostTypeSelector({ selected, setSelected }: PostTypeSelectorProps) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,7 +5,7 @@ export interface Post {
     feedback: 'positive' | 'neutral' | 'negative' | null
   }
   
-  export type PostFlavor = 'humblebrag' | 'fake_humility' | 'straight_fire'
+  export type PostFlavor = 'fanatic_leadership' | 'data_driven_hustle' | 'never_say_die'
   
   export type PostType = {
     id: number


### PR DESCRIPTION
## Summary
- update copy and seed data to revolve around RCB's big win
- rename flavor buttons to RCB-inspired lessons
- adjust heading and button text for new theme
- tweak OpenAI prompt for RCB theme

## Testing
- `npm install` *(passed)*
- `npm run lint` *(failed: ESLint not installed)*
- `npm run build` *(failed: build errors and missing env)*

------
https://chatgpt.com/codex/tasks/task_e_683f4ee0f9408327ade626c16c33bf23